### PR TITLE
Musl libc fixes

### DIFF
--- a/include/core/posix/standard_stream.h
+++ b/include/core/posix/standard_stream.h
@@ -23,6 +23,11 @@
 
 #include <cstdint>
 
+// Musl uses "#define stdin (stdin)", so the enum declaration fails with a syntax error
+#undef stdin
+#undef stdout
+#undef stderr
+
 namespace core
 {
 namespace posix

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(
 
   ${Boost_LIBRARIES}
   ${CMAKE_THREAD_LIBS_INIT}
+  execinfo
 )
 
 # We compile with all symbols visible by default. For the shipping library, we strip

--- a/src/core/posix/signal.cpp
+++ b/src/core/posix/signal.cpp
@@ -151,7 +151,7 @@ public:
             {
                 auto result = ::read(scope.signal_fd, signal_info, sizeof(signal_info));
 
-                for (uint i = 0; i < result / sizeof(signalfd_siginfo); i++)
+                for (unsigned int i = 0; i < result / sizeof(signalfd_siginfo); i++)
                 {
                     if (has(static_cast<core::posix::Signal>(signal_info[i].ssi_signo)))
                     {


### PR DESCRIPTION
The undefs are explained in the file

execinfo link: fixes
```
/usr/lib/gcc/x86_64-alpine-linux-musl/8.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: CMakeFiles/process-cpp.dir/core/posix/backtrace.cpp.o: in function `core::posix::backtrace::visit_with_handler(std::function<bool (core::posix::backtrace::Frame const&)> const&)':
backtrace.cpp:(.text+0x6a0): undefined reference to `backtrace'
/usr/lib/gcc/x86_64-alpine-linux-musl/8.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: backtrace.cpp:(.text+0x6ac): undefined reference to `backtrace_symbols'
```

and uint isn't standard, but unsigned int is.